### PR TITLE
Add aine_api decorator

### DIFF
--- a/aine_drl/__init__.py
+++ b/aine_drl/__init__.py
@@ -1,1 +1,3 @@
+from .util import aine_api
+
 from .agent import *

--- a/aine_drl/util/__init__.py
+++ b/aine_drl/util/__init__.py
@@ -1,0 +1,1 @@
+from .decorator import *

--- a/aine_drl/util/decorator.py
+++ b/aine_drl/util/decorator.py
@@ -1,0 +1,10 @@
+def aine_api(func):
+    """
+    Function decorator to label and check AINE API methods.
+    
+    Example:
+        @aine_api\\
+        def foo():
+            print("bar")
+    """
+    return func


### PR DESCRIPTION
If you define a standard API method, you must define aine_api decorator for it.